### PR TITLE
Fixed the compile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,11 @@ ifneq ($(BUILD),$(notdir $(CURDIR)))
 
 export OUTPUT	:=	$(CURDIR)/$(OUTDIR)/$(TARGET)
 export TOPDIR	:=	$(CURDIR)
-
+export DEPSDIR	:=	$(CURDIR)/$(BUILD)
 export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
 			$(foreach dir,$(DATA),$(CURDIR)/$(dir))
 
-DEPSDIR	:=	$(CURDIR)/$(BUILD)
+
 
 CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
 CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))


### PR DESCRIPTION
make -C source/mbedtls/lib all
make[1]: Entering directory '/somedirs/kezplez-nx/source/mbedtls/lib'
aes.c
aes.c:2119:1: fatal error: opening dependency file /aes.d: Permission denied
}
^
compilation terminated.
make[1]: *** [/opt/devkitpro/devkitA64/base_rules:19: aes.o] Error 1
make[1]: Leaving directory '/somedirs/kezplez-nx/source/mbedtls/lib'
make: *** [Makefile:153: build] Error 2